### PR TITLE
ref: replace py2 style super calls

### DIFF
--- a/advocate/adapters.py
+++ b/advocate/adapters.py
@@ -12,7 +12,7 @@ class ValidatingHTTPAdapter(HTTPAdapter):
         self._validator = kwargs.pop('validator', None)
         if not self._validator:
             self._validator = AddrValidator()
-        super(ValidatingHTTPAdapter, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def init_poolmanager(self, connections, maxsize, block=DEFAULT_POOLBLOCK,
                          **pool_kwargs):

--- a/advocate/api.py
+++ b/advocate/api.py
@@ -49,7 +49,7 @@ class Session(RequestsSession):
     def mount(self, *args, **kwargs):
         """Wrapper around `mount()` to prevent a protection bypass"""
         if self.__mount_allowed:
-            super(Session, self).mount(*args, **kwargs)
+            super().mount(*args, **kwargs)
         else:
             raise MountDisabledException(
                 "mount() is disabled to prevent protection bypasses"

--- a/advocate/poolmanager.py
+++ b/advocate/poolmanager.py
@@ -35,7 +35,7 @@ key_fn_by_scheme = {
 
 class ValidatingPoolManager(PoolManager):
     def __init__(self, *args, **kwargs):
-        super(ValidatingPoolManager, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         # Make sure the API hasn't changed
         assert (hasattr(self, 'pool_classes_by_scheme'))

--- a/test/monkeypatching.py
+++ b/test/monkeypatching.py
@@ -37,4 +37,4 @@ class CheckedSocket(socket.socket):
             stack = traceback.extract_stack()
             if not any(self._check_frame_allowed(frame) for frame in stack):
                 raise DisallowedConnectException("calling socket.connect() unsafely!")
-        return super(CheckedSocket, self).connect(*args, **kwargs)
+        return super().connect(*args, **kwargs)


### PR DESCRIPTION
Replace python 2 style super calls aka calls the specify the parent class with the short hand.